### PR TITLE
Upload only zip files and unzip on the server directly

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -14,7 +14,5 @@ build:
   env:
     LIMIT_TOKENS: 10000
     OSF_PARAMS: 'change me'
-    OSF_DST: 'data'
-    SRV_DST: 'change me'
     SRV_PARAMS: 'change me'
 

--- a/echr/steps/generate_datasets.py
+++ b/echr/steps/generate_datasets.py
@@ -81,7 +81,6 @@ def generate_dataset(cases, keys, keys_list, encoded_outcomes, feature_index, fe
                     f_db.write(' '.join(map(str, bow)) + ' \n')
                     f_b.write(' '.join(map(str, bow)) + ' \n')
                     nb_features += len(bow)
-                print(processed_folder, os.path.join(processed_folder, 'tfidf', '{}_tfidf.txt'.format(c['itemid'])))
                 with open(os.path.join(processed_folder, 'tfidf', '{}_tfidf.txt'.format(c['itemid'])), 'r') as tfidf_doc:
                     tfidf = tfidf_doc.read()
                     tfidf = tfidf.split()
@@ -229,7 +228,6 @@ def run(console, build, articles=[], processed_folder='all', force=True):
         ccl = c[conclusion_key]
         for e in ccl:
             if e['type'] in ['violation', 'no-violation']:
-                # print(c['itemid'], e)
                 if e['article'] not in outcomes:
                     outcomes[e['article']] = {
                         'violation': 0,

--- a/echr/steps/generate_sqlite.py
+++ b/echr/steps/generate_sqlite.py
@@ -241,7 +241,7 @@ def main(args):
     console = Console(record=True)
     run(console,
         build=args.build,
-        cases= args.cases,
+        cases=args.cases,
         force=args.f,
         update=args.u)
 

--- a/echr/steps/normalize_documents.py
+++ b/echr/steps/normalize_documents.py
@@ -157,7 +157,7 @@ def run(console, build, force=False, update=False):
                 TimeRemainingColumn(),
                 "| Document [blue]{task.fields[doc]} [white]({task.completed}/{task.total})"
                 "{task.fields[error]}",
-                transient=False,
+                transient=True,
         ) as progress:
             task = progress.add_task("Compute tokens...", total=len(corpus_id), error="", doc=corpus_id[0])
             for i, doc in enumerate(normalized_tokens):

--- a/tests/test_cases_info.py
+++ b/tests/test_cases_info.py
@@ -79,4 +79,4 @@ class TestGetCasesInfo:
 
         rc = get_case_info(base_url="", max_documents=100, path='/tmp/')
         assert rc == 1
-        assert os.stat('/tmp/0.json').st_size == 0
+        assert not os.path.isfile('/tmp/0.json')

--- a/workflows/local.yml
+++ b/workflows/local.yml
@@ -34,7 +34,5 @@ steps:
   - title: 'Generate SQL database'
     run: echr.steps.generate_sqlite
     updatable: true
-    args:
-      cases: './build/echr_database/unstructured/cases.json'
 
 


### PR DESCRIPTION
This improvement is made possible by https://github.com/echr-od/ECHR-OD_process/issues/93.
Deployment consists now in uploading only `all.zip` and `datasets.zip`. These two archives contain 1) the whole database documents, as well as raw documents and 2) the datasets for the experiments.

The archives are then decompressed on the remote server.

**_Example of usage:_**

Two environment variables are needed:
- `ECHR_PASSWORD`: string: server password
- `SRV_PARAMS`: string: information about the server and where to upload the build.
 e.g.: `'host=myserver.com user=aquemy folder=/home/aquemy/echr_build'`

Example of usage with docker:
`docker run -we "ECHR_PASSWORD=<hack me>" -e SRV_PARAMS='host=<ip or host> user=<hack me>  folder=<path>' -ti --mount src=$(pwd),dst=/tmp/echr_process/,type=bind echr_build build --workflow release`

Internally, the script will call:
`ssh/scp user@host:path`
and use `ECHR_PASSWORD` as password.
